### PR TITLE
Pass the new qualify-build-action inputs through

### DIFF
--- a/.github/workflows/pull_request_upkeep.yml
+++ b/.github/workflows/pull_request_upkeep.yml
@@ -10,9 +10,7 @@ jobs:
   upkeep:
     runs-on: ubuntu-latest
     steps:
-      - uses: Arda-cards/pull-request-setup-action@v1
+      - uses: Arda-cards/pull-request-setup-action@v2
         with:
-          iteration_field_name: "Iteration"
-          project_title: "${{ vars.ARDA_CLOUD_PROJECT_NAME }}"
           pull_request_number: "${{ github.event.pull_request.number }}"
           token: "${{ secrets.ARDA_GH_ACTION_PROJECT_WRITER }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [1.4.0] - 2026-08-07
+
+### Added
+
+- Two inputs passed straight through to `qualify-build-action`, both with the same defaults it uses, so
+  no consumer changes: `validate_against_base`, which a repository composing its changelog after merge
+  sets to `false` because its pull requests introduce no new version; and `changelog_dir`, naming the
+  directory whose file may carry a `feature-build:` marker. A repository reaches this action rather than
+  `qualify-build-action` directly, so without the passthrough neither input is usable.
+
 ## [1.3.9] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 
 ### Added
 
+- Pull-request upkeep follows `accounts` onto `pull-request-setup-action@v2`, dropping the
+  `project_title` and `iteration_field_name` inputs. The GitHub "Product Roadmap" project they
+  reference is obsolete — tracking moved to Linear — so the step failed looking for a project that no
+  longer exists.
 - Two inputs passed straight through to `qualify-build-action`, both with the same defaults it uses, so
   no consumer changes: `validate_against_base`, which a repository composing its changelog after merge
   sets to `false` because its pull requests introduce no new version; and `changelog_dir`, naming the

--- a/action.yaml
+++ b/action.yaml
@@ -2,6 +2,10 @@
 name: gradle-build-pipeline
 description: "Checkout, build and tag gradle projects"
 inputs:
+  changelog_dir:
+    description: "Directory holding per-pull-request changelog files; passed to qualify-build-action."
+    required: false
+    default: .changelog
   docker_registry:
     description: "The registry to persist Docker images"
     required: true
@@ -21,6 +25,12 @@ inputs:
   token:
     description: "The workflow's GitHub token"
     required: true
+  validate_against_base:
+    description: >-
+      Whether a pull request must introduce exactly one new changelog version.
+      Set false where the changelog is composed after merge; passed to qualify-build-action.
+    required: false
+    default: "true"
 outputs:
   chart_name:
     description: "The name of the helm chart, if published"
@@ -95,6 +105,8 @@ runs:
     - uses: Arda-cards/qualify-build-action@v2
       id: qualify-build
       with:
+        changelog_dir: ${{ inputs.changelog_dir }}
+        validate_against_base: ${{ inputs.validate_against_base }}
         workflow_name: "context:build"
     - name: "Tag source"
       shell: bash


### PR DESCRIPTION
Forwards two inputs added in [qualify-build-action#8](https://github.com/Arda-cards/qualify-build-action/pull/8), with the same defaults, so no current consumer changes:

- **`validate_against_base`** — a repository composing its changelog after merge sets this `false`, because its pull requests introduce no new `CHANGELOG.md` version and `clq-action` would otherwise reject every one of them.
- **`changelog_dir`** — names the directory whose single file may carry a `feature-build:` frontmatter marker.

Both are unusable without this: `operations`, `common-module` and the other four consumers reach `qualify-build-action` through this wrapper, never directly.

Needed for [PDEV-1408](https://linear.app/ardacards/issue/PDEV-1408). Merge after qualify-build-action#8, since `@v2` must already carry the inputs.

> [!note]
> Authored by Claude Opus 5 for jmpicnic