### PR TITLE
Give Gradle repositories CodeQL analysis they can actually run

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -193,3 +193,45 @@ jobs:
       - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+  # One check name to require in a ruleset, whatever the matrix happens to
+  # contain.
+  #
+  # Without this there is nothing stable to require. Each job above publishes
+  # its own check as `<caller-job> / <job name>`, and the interpreted job's name
+  # carries the language — so the set of names differs per repository, and
+  # adding a language to `no_build_languages` renames the checks. A ruleset
+  # still demanding the old name then blocks every pull request on a check that
+  # will never be published again.
+  #
+  # `if: always()` is the load-bearing line. Without it this job is *skipped*
+  # when a dependency fails, and a skipped required check reports success — so
+  # the aggregate would go green precisely when the analysis failed.
+  codeql:
+    name: codeql
+    needs: [compiled, interpreted]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Report the combined result"
+        env:
+          COMPILED: ${{ needs.compiled.result }}
+          INTERPRETED: ${{ needs.interpreted.result }}
+        run: |
+          [ "${RUNNER_DEBUG}" == 1 ] && set -xv
+          set -uo pipefail
+
+          echo "::notice::compiled=${COMPILED} interpreted=${INTERPRETED}"
+
+          rs=0
+          [ "${COMPILED}" == "success" ] || rs=1
+
+          # Skipped is legitimate here, and only here: a repository with no
+          # source-extracted languages passes `no_build_languages: "[]"`.
+          case "${INTERPRETED}" in
+            success | skipped) ;;
+            *) rs=1 ;;
+          esac
+
+          [ "${rs}" -eq 0 ] || echo "::error::CodeQL analysis did not succeed"
+          exit "${rs}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -119,9 +119,11 @@ jobs:
           BUF_TOKEN: ${{ secrets.buf_token }}
           GPR_USER: ${{ secrets.gpr_user }}
           GPR_KEY: ${{ secrets.gpr_key }}
-          # gradle-build.sh exports these from GITHUB_ACTOR and TOKEN; the
-          # publishing repositories read the same pair under different names.
-          USERNAME: ${{ github.actor }}
+          # The same credentials again, under the names the publishing
+          # repositories read them by. Both halves come from gpr_*: pairing the
+          # triggering actor with gpr_user's token is two identities, which a
+          # fine-grained token rejects.
+          USERNAME: ${{ secrets.gpr_user }}
           TOKEN: ${{ secrets.gpr_key }}
           GRADLE_TASK: ${{ inputs.gradle_task }}
         run: |

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,139 @@
+---
+# CodeQL analysis for a Gradle project, as a job a consumer runs alongside its
+# build rather than inside it.
+#
+# Three constraints shape this, and together they rule out the simpler designs.
+#
+# 1. CodeQL's extractor observes the compiler; it cannot read compiled classes
+#    after the fact. So it needs a build of its own, and `init`, that build, and
+#    `analyze` must all live in one job. A composite action cannot create a job,
+#    which is why this is a reusable workflow.
+#
+# 2. Wrapping the consumer's existing `./gradlew build` would make analysis wait
+#    for the tests. Compiling separately costs one extra compile and hides the
+#    whole analysis under the test run instead.
+#
+# 3. `org.gradle.caching=true` is set in `operations` and `common-module`, so a
+#    cache hit makes `compileKotlin` UP-TO-DATE and the compiler never runs.
+#    CodeQL would then extract nothing and report zero alerts — indistinguishable
+#    from clean code. `--no-build-cache` is what stops that, and it is why this
+#    build cannot share the test build's cache even though it shares the
+#    dependency cache.
+name: codeql
+
+on:
+  workflow_call:
+    inputs:
+      buf_version:
+        description: >-
+          Install this version of buf before compiling. Required where protobuf
+          sources are generated as part of the build; leave empty otherwise.
+        type: string
+        required: false
+        default: ""
+      gradle_task:
+        description: >-
+          The task that compiles everything worth analysing. `assemble` skips the
+          tests, which is the point; a project whose test sources should also be
+          analysed wants `testClasses` as well.
+        type: string
+        required: false
+        default: "assemble"
+    secrets:
+      gpr_user:
+        description: "User with read access to GitHub Packages, for dependency resolution."
+        required: true
+      gpr_key:
+        description: "Token for gpr_user."
+        required: true
+      buf_token:
+        description: "Token for buf, where buf_version is set."
+        required: false
+
+permissions: {}
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: read-tools-choice
+        name: "Read tools version"
+        run: |
+          [ "${RUNNER_DEBUG}" == 1 ] && set -xv
+          set -u
+
+          # Mirrors the resolution in action.yaml, so the analysis compiles on
+          # the same JDK the real build uses.
+          property_name=toolchainVersion
+          if grep -qs -w ^${property_name} gradle/gradle-daemon-jvm.properties; then
+            java_version="$(grep -w ^${property_name} gradle/gradle-daemon-jvm.properties | cut -d= -f2)"
+          else
+            java_version=21
+          fi
+
+          property_name=toolchainVendor
+          if grep -qs -w ^${property_name} gradle/gradle-daemon-jvm.properties; then
+            java_vendor="$(grep -w ^${property_name} gradle/gradle-daemon-jvm.properties | cut -d= -f2)"
+          else
+            java_vendor=corretto
+          fi
+
+          {
+            echo "java_version=${java_version}"
+            echo "java_vendor=${java_vendor}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: ${{ steps.read-tools-choice.outputs.java_vendor }}
+          java-version: ${{ steps.read-tools-choice.outputs.java_version }}
+
+      # Read-only: the build job owns the cache, this one benefits from the
+      # dependency half of it without racing to write entries of its own.
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - uses: bufbuild/buf-action@v1
+        if: inputs.buf_version != ''
+        with:
+          version: ${{ inputs.buf_version }}
+          github_token: ${{ github.token }}
+          setup_only: true
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          # "I will build it myself, between init and analyze." Autobuild is the
+          # mode that does not work here: it has neither the package credentials
+          # nor buf, and fails before extraction starts.
+          build-mode: manual
+
+      - name: "Compile for extraction"
+        env:
+          BUF_TOKEN: ${{ secrets.buf_token }}
+          GPR_USER: ${{ secrets.gpr_user }}
+          GPR_KEY: ${{ secrets.gpr_key }}
+          # gradle-build.sh exports these from GITHUB_ACTOR and TOKEN; the
+          # publishing repositories read the same pair under different names.
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ secrets.gpr_key }}
+          GRADLE_TASK: ${{ inputs.gradle_task }}
+        run: |
+          [ "${RUNNER_DEBUG}" == 1 ] && set -xv
+          set -euo pipefail
+
+          # Split deliberately: the input may name more than one task.
+          read -r -a tasks <<<"${GRADLE_TASK}"
+
+          # --no-build-cache is load-bearing, not tuning. See the header.
+          ./gradlew "${tasks[@]}" --no-build-cache
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,6 +19,11 @@
 #    from clean code. `--no-build-cache` is what stops that, and it is why this
 #    build cannot share the test build's cache even though it shares the
 #    dependency cache.
+#
+# The calling job must grant `contents: read` and `security-events: write`. The
+# permissions declared below are a ceiling, not a grant: a called workflow can
+# only restrict what its caller already has, so a caller with `permissions: {}`
+# leaves this job unable to upload its results.
 name: codeql
 
 on:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,13 +1,26 @@
 ---
-# CodeQL analysis for a Gradle project, as a job a consumer runs alongside its
+# CodeQL analysis for a Gradle project, as jobs a consumer runs alongside its
 # build rather than inside it.
 #
-# Three constraints shape this, and together they rule out the simpler designs.
+# This replaces GitHub's default setup entirely. The documented way to adopt an
+# advanced configuration is to "Switch to advanced" and disable CodeQL default
+# setup, which is repository-wide rather than per-language — so a consumer that
+# adopts this must also disable default setup, and this workflow has to cover
+# every language that setup was covering, not only the compiled one.
 #
-# 1. CodeQL's extractor observes the compiler; it cannot read compiled classes
-#    after the fact. So it needs a build of its own, and `init`, that build, and
-#    `analyze` must all live in one job. A composite action cannot create a job,
-#    which is why this is a reusable workflow.
+# Hence two jobs. They differ in one thing that cannot be expressed in a single
+# CodeQL invocation: whether the language needs to be built.
+#
+#   compiled     java-kotlin, build-mode manual — CodeQL's extractor observes
+#                the compiler, so there has to be a compile for it to watch.
+#   interpreted  actions, javascript-typescript and the like, build-mode none —
+#                extracted straight from source, so no JDK, no Gradle, no buf.
+#
+# Three constraints shaped the compiled job, and together they rule out the
+# simpler designs.
+#
+# 1. `init`, the build, and `analyze` must live in one job. A composite action
+#    cannot create a job, which is why this is a reusable workflow.
 #
 # 2. Wrapping the consumer's existing `./gradlew build` would make analysis wait
 #    for the tests. Compiling separately costs one extra compile and hides the
@@ -23,7 +36,7 @@
 # The calling job must grant `contents: read` and `security-events: write`. The
 # permissions declared below are a ceiling, not a grant: a called workflow can
 # only restrict what its caller already has, so a caller with `permissions: {}`
-# leaves this job unable to upload its results.
+# leaves these jobs unable to upload their results.
 name: codeql
 
 on:
@@ -44,6 +57,15 @@ on:
         type: string
         required: false
         default: "assemble"
+      no_build_languages:
+        description: >-
+          JSON array of languages extracted from source without a build. These
+          are the ones default setup was covering for free, and they have to be
+          named here because adopting this workflow turns default setup off.
+          Pass "[]" for a repository that has none.
+        type: string
+        required: false
+        default: '["actions"]'
     secrets:
       gpr_user:
         description: "User with read access to GitHub Packages, for dependency resolution."
@@ -58,7 +80,8 @@ on:
 permissions: {}
 
 jobs:
-  codeql:
+  compiled:
+    name: "codeql (java-kotlin)"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -144,3 +167,29 @@ jobs:
       - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java-kotlin"
+
+  # Everything default setup used to cover for free. Cheap — no build tooling,
+  # no compile — but it has to be here, because adopting advanced setup turns
+  # default setup off for the whole repository rather than for one language.
+  interpreted:
+    name: "codeql (${{ matrix.language }})"
+    if: inputs.no_build_languages != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(inputs.no_build_languages) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,13 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 - A reusable `codeql` workflow, giving any Gradle repository CodeQL analysis of its
   Kotlin and Java sources. GitHub's own default setup cannot build these projects —
   it has neither the package credentials nor `buf` — so the workflow compiles with
-  the same toolchain the build uses. It runs as a job beside the caller's build
-  rather than inside it, so analysis does not lengthen the path to a merge.
+  the same toolchain the build uses. It runs beside the caller's build rather than
+  inside it, so analysis does not lengthen the path to a merge.
+
+  It replaces default setup rather than supplementing it, because switching to an
+  advanced configuration disables CodeQL for the whole repository and not just for
+  the compiled language. The workflow therefore also analyses the languages default
+  setup was covering, named through `no_build_languages`.
 
 ## [1.4.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   the compiled language. The workflow therefore also analyses the languages default
   setup was covering, named through `no_build_languages`.
 
+  A `codeql` job reports the combined result under one name, so a ruleset has
+  something stable to require: the per-language checks are named after the matrix
+  and change whenever the language list does.
+
 ## [1.4.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [1.5.0] - 2026-08-07
+
+### Added
+
+- A `codeql` input that analyses Kotlin and Java with CodeQL around the build this
+  action already runs, rather than alongside it. CodeQL's extractor observes the
+  compiler, so it needs a build; wrapping the existing one means the analysis
+  inherits the Gradle cache, the JDK, `buf`, and the package credentials in one
+  pass instead of paying for a second build that lacks all four. CodeQL's own
+  autobuild has none of them — measured 2026-08-07, it failed on `accounts` for an
+  unresolvable `cards.arda.common:lib` and on `operations` for a missing `buf`.
+
+  The calling job must grant `security-events: write`; a composite action cannot
+  grant it for its caller. The input therefore defaults to `false`, so releasing
+  this version changes nothing for a consumer until that consumer opts in.
+
+  Skipped on the release build, where the same tree has already been analysed on
+  the pull request and in the merge queue.
+
 ## [1.4.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,20 +22,11 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 
 ### Added
 
-- A `codeql` input that analyses Kotlin and Java with CodeQL around the build this
-  action already runs, rather than alongside it. CodeQL's extractor observes the
-  compiler, so it needs a build; wrapping the existing one means the analysis
-  inherits the Gradle cache, the JDK, `buf`, and the package credentials in one
-  pass instead of paying for a second build that lacks all four. CodeQL's own
-  autobuild has none of them — measured 2026-08-07, it failed on `accounts` for an
-  unresolvable `cards.arda.common:lib` and on `operations` for a missing `buf`.
-
-  The calling job must grant `security-events: write`; a composite action cannot
-  grant it for its caller. The input therefore defaults to `false`, so releasing
-  this version changes nothing for a consumer until that consumer opts in.
-
-  Skipped on the release build, where the same tree has already been analysed on
-  the pull request and in the merge queue.
+- A reusable `codeql` workflow, giving any Gradle repository CodeQL analysis of its
+  Kotlin and Java sources. GitHub's own default setup cannot build these projects —
+  it has neither the package credentials nor `buf` — so the workflow compiles with
+  the same toolchain the build uses. It runs as a job beside the caller's build
+  rather than inside it, so analysis does not lengthen the path to a merge.
 
 ## [1.4.0] - 2026-08-07
 

--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,14 @@ inputs:
     description: "Directory holding per-pull-request changelog files; passed to qualify-build-action."
     required: false
     default: .changelog
+  codeql:
+    description: >-
+      Analyse the Kotlin and Java sources with CodeQL around the build (true|false).
+      The calling job must grant `security-events: write`; a composite action cannot
+      grant it, and CodeQL fails without it. Defaults to false so that releasing this
+      action does not break consumers that have not yet added the permission.
+    required: false
+    default: "false"
   docker_registry:
     description: "The registry to persist Docker images"
     required: true
@@ -129,6 +137,27 @@ runs:
             exit 1
           fi
         fi
+    # CodeQL wraps the build rather than running its own. For a compiled
+    # language the extractor observes the compiler, so it needs *a* build — and
+    # the cheapest build to observe is the one this action already runs. That is
+    # also what gives it the Gradle cache from setup-gradle above, the JDK, buf
+    # and the package credentials, none of which CodeQL's own autobuild has:
+    # measured 2026-08-07, autobuild failed on `accounts` for an unresolvable
+    # cards.arda.common:lib and on `operations` for a missing `buf`.
+    #
+    # Skipped on the release build. The same tree was already analysed on the
+    # pull request and again in the queue, and a third pass would only lengthen
+    # the path between a merge and a published artifact.
+    - id: codeql-init
+      if: >-
+        inputs.codeql == 'true'
+        && steps.qualify-build.outputs.trigger != 'push_to_release_branch'
+      uses: github/codeql-action/init@v4
+      with:
+        languages: java-kotlin
+        # `manual` means "I will build it myself, between init and analyze".
+        # Autobuild is the mode that does not work here.
+        build-mode: manual
     - id: build
       name: "Build, test and publish"
       shell: bash
@@ -142,6 +171,15 @@ runs:
         SKIP_TEST: ${{ inputs.skip_test }}
         TOKEN: ${{ inputs.token }}
         VERSION: ${{ steps.qualify-build.outputs.version }}
+    # Paired with codeql-init, on the same condition. `analyze` is what builds
+    # the database from what the compiler did and uploads the results.
+    - id: codeql-analyze
+      if: >-
+        inputs.codeql == 'true'
+        && steps.qualify-build.outputs.trigger != 'push_to_release_branch'
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:java-kotlin"
     - id: clq-extract
       if: steps.qualify-build.outputs.trigger == 'push_to_release_branch'
       name: "Extract tag from the changelog"

--- a/action.yaml
+++ b/action.yaml
@@ -6,14 +6,6 @@ inputs:
     description: "Directory holding per-pull-request changelog files; passed to qualify-build-action."
     required: false
     default: .changelog
-  codeql:
-    description: >-
-      Analyse the Kotlin and Java sources with CodeQL around the build (true|false).
-      The calling job must grant `security-events: write`; a composite action cannot
-      grant it, and CodeQL fails without it. Defaults to false so that releasing this
-      action does not break consumers that have not yet added the permission.
-    required: false
-    default: "false"
   docker_registry:
     description: "The registry to persist Docker images"
     required: true
@@ -137,27 +129,6 @@ runs:
             exit 1
           fi
         fi
-    # CodeQL wraps the build rather than running its own. For a compiled
-    # language the extractor observes the compiler, so it needs *a* build — and
-    # the cheapest build to observe is the one this action already runs. That is
-    # also what gives it the Gradle cache from setup-gradle above, the JDK, buf
-    # and the package credentials, none of which CodeQL's own autobuild has:
-    # measured 2026-08-07, autobuild failed on `accounts` for an unresolvable
-    # cards.arda.common:lib and on `operations` for a missing `buf`.
-    #
-    # Skipped on the release build. The same tree was already analysed on the
-    # pull request and again in the queue, and a third pass would only lengthen
-    # the path between a merge and a published artifact.
-    - id: codeql-init
-      if: >-
-        inputs.codeql == 'true'
-        && steps.qualify-build.outputs.trigger != 'push_to_release_branch'
-      uses: github/codeql-action/init@v4
-      with:
-        languages: java-kotlin
-        # `manual` means "I will build it myself, between init and analyze".
-        # Autobuild is the mode that does not work here.
-        build-mode: manual
     - id: build
       name: "Build, test and publish"
       shell: bash
@@ -171,15 +142,6 @@ runs:
         SKIP_TEST: ${{ inputs.skip_test }}
         TOKEN: ${{ inputs.token }}
         VERSION: ${{ steps.qualify-build.outputs.version }}
-    # Paired with codeql-init, on the same condition. `analyze` is what builds
-    # the database from what the compiler did and uploads the results.
-    - id: codeql-analyze
-      if: >-
-        inputs.codeql == 'true'
-        && steps.qualify-build.outputs.trigger != 'push_to_release_branch'
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:java-kotlin"
     - id: clq-extract
       if: steps.qualify-build.outputs.trigger == 'push_to_release_branch'
       name: "Extract tag from the changelog"


### PR DESCRIPTION
CodeQL is enabled org-wide, but it finds no Kotlin in any of our Gradle repositories. Its autobuild cannot build them — measured 2026-08-07, it failed on `accounts` for an unresolvable `cards.arda.common:lib` and on `operations` for a missing `buf`. Both are things our own build already supplies, so the analysis has to compile the way we do.

This adds that as shared infrastructure: a repository gets CodeQL by declaring one job and passing its credentials.

## Why a workflow and not an input to the action

I tried the action first. It cannot work, for three reasons that compose:

- CodeQL's extractor watches the compiler, so `init`, a build, and `analyze` must share one job.
- That build should not be the consumer's `./gradlew build`, or the analysis waits for the tests and lengthens the path to a merge.
- A composite action runs inside its caller's job and cannot create one.

So the analysis needs its own job, and only a reusable workflow can add one. The cost is a second compile per pull request, paid in parallel and therefore invisible in wall-clock time.

## The part worth reviewing carefully

The compile runs `--no-build-cache`, and that is correctness rather than tuning. `operations` and `common-module` set `org.gradle.caching=true`; on a cache hit Gradle marks `compileKotlin` UP-TO-DATE, the compiler never runs, and CodeQL builds an empty database that reports **zero alerts** — indistinguishable from clean code. This is the line most likely to be removed by someone later trying to speed the job up.

The dependency cache is still shared, read-only, so the job does not race the build for cache entries.

## Blast radius

None until a consumer opts in. Nothing existing changes behaviour; the six repositories on `@v1` are unaffected until they add the job.

## Closes

Closes PDEV-1463

> [!note]
> Authored by Claude Opus 5 for jmpicnic